### PR TITLE
Oneshot script for removing old cache dir

### DIFF
--- a/PackageKit/configure.ac
+++ b/PackageKit/configure.ac
@@ -776,6 +776,7 @@ contrib/gstreamer-plugin/Makefile
 contrib/gtk-module/Makefile
 contrib/gtk-module/gtk2/Makefile
 contrib/yum-packagekit/Makefile
+contrib/zypp-packagekit/Makefile
 contrib/command-not-found/Makefile
 contrib/cron/Makefile
 contrib/debuginfo-install/Makefile

--- a/PackageKit/contrib/Makefile.am
+++ b/PackageKit/contrib/Makefile.am
@@ -4,6 +4,10 @@ if BACKEND_TYPE_YUM
 SUBDIRS += yum-packagekit
 endif
 
+if BACKEND_TYPE_ZYPP
+SUBDIRS += zypp-packagekit
+endif
+
 if PK_BUILD_BROWSER_PLUGIN
 SUBDIRS += browser-plugin
 endif

--- a/PackageKit/contrib/zypp-packagekit/Makefile.am
+++ b/PackageKit/contrib/zypp-packagekit/Makefile.am
@@ -1,0 +1,4 @@
+oneshotdir=/usr/lib/oneshot.d
+dist_oneshot_DATA = pk-zypp-nemo-remove-old-cache
+
+-include $(top_srcdir)/git.mk

--- a/PackageKit/contrib/zypp-packagekit/README
+++ b/PackageKit/contrib/zypp-packagekit/README
@@ -1,0 +1,5 @@
+pk-zypp-nemo-remove-old-cache
+
+This Nemo-specific oneshot script removes old zypp cache directories after they
+have moved elsewhere.
+

--- a/PackageKit/contrib/zypp-packagekit/pk-zypp-nemo-remove-old-cache
+++ b/PackageKit/contrib/zypp-packagekit/pk-zypp-nemo-remove-old-cache
@@ -1,0 +1,12 @@
+#! /bin/sh
+
+# the outdated cache location that is to be removed
+OLD_CACHE=/var/cache/pk-zypp-dist-upgrade
+
+# it is always safe to remove the old location, even if the new location does
+# not exist, at the time of the oneshot-execution
+if [ -d "${OLD_CACHE}" ]; then
+  rm -rf "${OLD_CACHE}" >/dev/null 2>&1
+  exit $?
+fi
+

--- a/rpm/PackageKit.spec
+++ b/rpm/PackageKit.spec
@@ -63,6 +63,8 @@ cross-architecture API.
 %package zypp
 Summary: PackageKit zypp backend
 Group: System/Libraries
+%{_oneshot_requires_post}
+Requires: oneshot
 Requires: libzypp >= 5.20.0
 Requires: %{name} = %{version}-%{release}
 
@@ -275,6 +277,7 @@ update-mime-database %{_datadir}/mime &> /dev/null || :
 
 %post zypp
 /bin/systemctl preset rpm-db-clean.service >/dev/null 2>&1 || :
+%{_bindir}/add-oneshot pk-zypp-nemo-remove-old-cache
 
 %preun zypp
 %systemd_preun rpm-db-clean.service
@@ -331,6 +334,7 @@ update-mime-database %{_datadir}/mime &> /dev/null || :
 %{_unitdir}/rpm-db-clean.service
 %config %{_sysconfdir}/zypp/pk-zypp-cache.conf
 %dir /home/.pk-zypp-dist-upgrade-cache
+%attr(0755, -, -) %{_oneshotdir}/*
 
 %files glib
 %defattr(-,root,root,-)


### PR DESCRIPTION
Since the SDK has an older version of automake than the Makefile.in files in the git repo were created with, I didn't include my Makefile.in's, because that would have replaced all Makefile.in files of the whole project.